### PR TITLE
Add functionality for depth images (16UC1 and 32FC1)

### DIFF
--- a/opportunistic_link/include/opportunistic_link/image_compression.h
+++ b/opportunistic_link/include/opportunistic_link/image_compression.h
@@ -10,10 +10,6 @@ namespace image_compression
 {
     class ImageHandler
     {
-    protected:
-
-        ;
-
     public:
 
         ImageHandler() {}

--- a/opportunistic_link/src/opportunistic_link/image_compression.cpp
+++ b/opportunistic_link/src/opportunistic_link/image_compression.cpp
@@ -21,7 +21,12 @@ void ImageHandler::reset_decoder()
 sensor_msgs::Image ImageHandler::decompress_image(const sensor_msgs::CompressedImage& compressed, const std::string& encoding)
 {
     sensor_msgs::Image decompressed;
-    cv::Mat decoded = cv::imdecode(compressed.data, CV_LOAD_IMAGE_ANYCOLOR);
+    cv::Mat decoded = cv::imdecode(compressed.data, CV_LOAD_IMAGE_UNCHANGED);
+    if(decoded.data==NULL) {
+        ROS_WARN("Decoding unsuccessful");
+    } else {
+        ROS_DEBUG_STREAM("Decoding successful, rows=" << decoded.rows << ", cols=" << decoded.cols << ", opencv type=" << decoded.type());
+    }
     cv_bridge::CvImage converted;
     converted = cv_bridge::CvImage(compressed.header, encoding, decoded);
     converted.toImageMsg(decompressed);
@@ -37,9 +42,23 @@ sensor_msgs::CompressedImage ImageHandler::compress_image(const sensor_msgs::Ima
     cv_ptr = cv_bridge::toCvCopy(image);
     cv::Mat cv_image = cv_ptr->image;
     std::vector<int> encoding_params;
-    encoding_params.push_back(CV_IMWRITE_JPEG_QUALITY);
-    encoding_params.push_back(quality);
-    bool ret = cv::imencode(".jpg", cv_image, compressed.data, encoding_params);
+    bool ret;
+    ROS_DEBUG_STREAM("Image encoding: " << image.encoding);
+    if(image.encoding=="16UC1") {
+        ROS_DEBUG("Encoding in png format");
+        ret = cv::imencode(".png", cv_image, compressed.data, encoding_params);
+        compressed.format="png";
+    } else if(image.encoding=="32FC1") {
+        ROS_DEBUG("Encoding in tiff format");
+        ret = cv::imencode(".tiff", cv_image, compressed.data, encoding_params);
+        // jpeg and png are the only acceptable values for the format field, so it is not set here
+    } else {
+        ROS_DEBUG("Encoding in jpeg format");
+        encoding_params.push_back(CV_IMWRITE_JPEG_QUALITY);
+        encoding_params.push_back(quality);
+        ret = cv::imencode(".jpg", cv_image, compressed.data, encoding_params);
+        compressed.format="jpeg";
+    }
     if (ret)
     {
         ROS_DEBUG("OpenCV encoding success");


### PR DESCRIPTION
This PR adds functionality to compress images of type 16UC1 and 32FC1, which are common formats for depth images. These types cannot be compressed with jpeg, so png respectively tiff are used.
This PR also adds some debug output.